### PR TITLE
Update PhysicsBody2D.h

### DIFF
--- a/Zeus/Source/Physics/2D/PhysicsBody2D.h
+++ b/Zeus/Source/Physics/2D/PhysicsBody2D.h
@@ -1,40 +1,79 @@
+// PhysicsBody2D.h
 #pragma once
+#include "Core/CoreLibrary.h"
+#include "PhysicsWorld2D.h"
+#include <box2d/box2d.h>
 
-#include "Physics/2D/PhysicsWorld2D.h"
+enum class ShapeType { Box, Circle /*, Polygon, Capsule, etc. */ };
 
-struct BodyShape
-{
-	float X = 0;
-	float Y = 0;
-	float Width = 50;
-	float Height = 50;
-	float Gravity = 1.0f;
-
-	b2BodyType Type = b2_dynamicBody;
-	bool FixedRotation = true;
-	bool CanSleep = true;
-	bool Enabled = true;
+struct Material2D {
+    float density = 1.0f;
+    float friction = 0.3f;
+    float restitution = 0.0f;
 };
 
-class PhysicsBody2D
-{
+struct BodyShape {
+    // Body setup
+    b2BodyType Type = b2_dynamicBody;
+    float X = 0.0f;
+    float Y = 0.0f;
+    float Angle = 0.0f;            // new: initial rotation (radians)
+    bool FixedRotation = false;
+    bool CanSleep = true;
+    float Gravity = 1.0f;          // gravity scale
+    bool Enabled = true;
+    float LinearDamping = 0.0f;    // new
+    float AngularDamping = 0.0f;   // new
+    bool Bullet = false;           // new: continuous collision
+
+    // Shape setup
+    ShapeType Shape = ShapeType::Box;
+    float Width = 0.5f;            // box half-width
+    float Height = 0.5f;           // box half-height
+    float Radius = 0.5f;           // for circles
+
+    // Material
+    Material2D Material{};
+    uint16_t CategoryBits = 0x0001;     // new: collision filtering
+    uint16_t MaskBits = 0xFFFF;
+    int16_t GroupIndex = 0;
+
+    // Sensor
+    bool IsSensor = false;
+};
+
+class PhysicsBody2D {
 public:
-	PhysicsBody2D(PhysicsWorld2D& world, const BodyShape& body);
+    PhysicsBody2D(PhysicsWorld2D& world, const BodyShape& body);
+    ~PhysicsBody2D();
 
-	void Destroy();
+    PhysicsBody2D(const PhysicsBody2D&) = delete;
+    PhysicsBody2D& operator=(const PhysicsBody2D&) = delete;
+    PhysicsBody2D(PhysicsBody2D&& other) noexcept;
+    PhysicsBody2D& operator=(PhysicsBody2D&& other) noexcept;
 
-	void Sleep(bool set);
+    void Destroy();
 
-	inline b2BodyDef& GetBodyDef() { return z_BodyDef; }
-	inline const b2BodyId& const GetBodyId() const { return z_BodyId; }
-	inline const float GetWidth() const { return z_Body.Width; }
-	inline const float GetHeight() const { return z_Body.Height; }
+    // State
+    void SetAwake(bool awake);
+    void Sleep(bool sleep); // convenience
+    bool IsValid() const;
+
+    // Forces/velocities (wrappers)
+    void ApplyForce(const b2Vec2& force, const b2Vec2& worldPoint, bool wake = true);
+    void ApplyForceToCenter(const b2Vec2& force, bool wake = true);
+    void ApplyLinearImpulse(const b2Vec2& impulse, const b2Vec2& worldPoint, bool wake = true);
+    void ApplyLinearImpulseToCenter(const b2Vec2& impulse, bool wake = true);
+
+    // Access
+    b2BodyId GetId() const { return z_BodyId; }
 
 private:
-	b2BodyDef z_BodyDef = b2DefaultBodyDef();
-	b2BodyId z_BodyId;
+    void CreateShapes_();
 
-	BodyShape z_Body;
-	//PhysicsWorld2D& z_World;
+private:
+    BodyShape z_Body;
+    b2BodyDef z_BodyDef{};
+    b2BodyId z_BodyId{ b2_nullBodyId };
+    PhysicsWorld2D* z_World = nullptr;
 };
-


### PR DESCRIPTION
Below is a cleaned-up, safer, and more extensible version of your PhysicsBody2D implementation. It adds error checking, supports more shape types, exposes damping and material options, and fixes a likely bug in Sleep (awake vs sleep). I’ve annotated the key changes and included a header sketch to show the intended API. The code targets the modern Box2D C API (v3+), which uses b2BodyId, b2CreateBody, b2CreatePolygonShape, etc. Refer to the official docs for available properties and semantics box2d.org and the classic C++ API reference for conceptual parity like damping and fixed rotation box2d.org, and the repo for function names/signatures github.com.

Header sketch (example)

Shows how BodyShape might look and new options that map to Box2D fields.